### PR TITLE
Kubernetes intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,8 @@ yunusovtr Platform repository
 - Задание: Разберитесь почему все pod в namespace kube-system восстановились
   - поды для etcd, kube-apiserver, kube-controller-manager, kube-scheduler являются статичными и управляет ими kubelet ноды, которая в minikube имеет имя minikube. Манифесты для них находятся в обычных файлах /etc/kubernetes/manifests.
   - core-dns и kube-proxy - это Deployment и DaemonSet, манифесты которых сохраняются в базе etcd и становятся доступными после поднятия пода etcd.
-- 
+- Подготовил Dockerfile для web-сервера nginx по условиям
+- Создал манифест пода web, создал основной и инит-контейнеры, проверил работоспособность пода и открытие целевой страницы
+- Склонировал репозиторий https://github.com/GoogleCloudPlatform/microservices-demo
+- Собрал образ hipster-frontend, отправил в docker hub
+- Задание со *: добавил все переменные окружения, необходимые для успешного старта контейнера, и статус пода после старта стал Running.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # yunusovtr_platform
 yunusovtr Platform repository
+
+## Домашнее задание к уроку №2
+
+- Подготовил репозиторий yunusovtr-platform для работы, внёс необходимые файлы для работы автотестов
+- Задание: Разберитесь почему все pod в namespace kube-system восстановились
+  - поды для etcd, kube-apiserver, kube-controller-manager, kube-scheduler являются статичными и управляет ими kubelet ноды, которая в minikube имеет имя minikube. Манифесты для них находятся в обычных файлах /etc/kubernetes/manifests.
+  - core-dns и kube-proxy - это Deployment и DaemonSet, манифесты которых сохраняются в базе etcd и становятся доступными после поднятия пода etcd.
+- 

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: yunusovtr/hipster-frontend:v0.0.1
+    name: frontend
+    resources: {}
+    env:
+      - name: PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
+      # # ENV_PLATFORM: One of: local, gcp, aws, azure, onprem, alibaba
+      # # When not set, defaults to "local" unless running in GKE, otherwies auto-sets to gcp 
+      # - name: ENV_PLATFORM 
+      #   value: "aws"
+      - name: DISABLE_TRACING
+        value: "1"
+      - name: DISABLE_PROFILER
+        value: "1"
+      # - name: CYMBAL_BRANDING
+      #   value: "true"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: yunusovtr/hipster-frontend:v0.0.1
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+    - name: web
+      image: yunusovtr/web
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  initContainers:
+    - name: init-web
+      image: busybox
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginxinc/nginx-unprivileged:latest
+COPY default.conf /etc/nginx/conf.d/
+USER 1001

--- a/kubernetes-intro/web/default.conf
+++ b/kubernetes-intro/web/default.conf
@@ -1,0 +1,44 @@
+server {
+    listen       8000;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /app;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
- Подготовил репозиторий yunusovtr-platform для работы, внёс необходимые файлы для работы автотестов
- Задание: Разберитесь почему все pod в namespace kube-system восстановились
  - поды для etcd, kube-apiserver, kube-controller-manager, kube-scheduler являются статичными и управляет ими kubelet ноды, которая в minikube имеет имя minikube. Манифесты для них находятся в обычных файлах /etc/kubernetes/manifests.
  - core-dns и kube-proxy - это Deployment и DaemonSet, манифесты которых сохраняются в базе etcd и становятся доступными после поднятия пода etcd.
- Подготовил Dockerfile для web-сервера nginx по условиям
- Создал манифест пода web, создал основной и инит-контейнеры, проверил работоспособность пода и открытие целевой страницы
- Склонировал репозиторий https://github.com/GoogleCloudPlatform/microservices-demo
- Собрал образ hipster-frontend, отправил в docker hub
- Задание со *: добавил все переменные окружения, необходимые для успешного старта контейнера, и статус пода после старта стал Running.

## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
